### PR TITLE
Rb/feat/prod transforms

### DIFF
--- a/json/components/network-sourcing/ns3.yml
+++ b/json/components/network-sourcing/ns3.yml
@@ -162,8 +162,8 @@ NS3.Node.ProductTransform.Item:
     productId:
       type: string
     productRatio:
-      type: number
-      format: float
+      type: integer
+      format: int32
     dimensionRanges:
       type: array
       items:

--- a/json/components/network-sourcing/ns3.yml
+++ b/json/components/network-sourcing/ns3.yml
@@ -536,6 +536,27 @@ NS3.SolutionResponse.Route:
         type: integer
         format: int32
 
+NS3.SolutionResponse.NodeProductTransformAssignment.Item:
+  type: object
+  properties:
+    productId:
+      type: string
+    amount:
+      type: number
+      format: float
+    cost:
+      type: number
+      format: float
+    fixedCost:
+      type: number
+      format: float
+    penaltyAmount:
+      type: number
+      format: float
+    penaltyCost:
+      type: number
+      format: float
+
 NS3.SolutionResponse.NodeProductTransformAssignment:
   type: object
   properties:
@@ -543,25 +564,15 @@ NS3.SolutionResponse.NodeProductTransformAssignment:
       type: string
     productTransformId:
       type: string
-    inputProductId:
+    inputItems:
       type: array
       items:
-        type: string
-    inputAmount:
+        $ref: '#/NS3.SolutionResponse.NodeProductTransformAssignment.Item'
+    outputItems:
       type: array
       items:
-        type: number
-        format: float
-    outputProductId:
-      type: array
-      items:
-        type: string
-    outputAmount:
-      type: array
-      items:
-        type: number
-        format: float
-
+        $ref: '#/NS3.SolutionResponse.NodeProductTransformAssignment.Item'
+    
 NS3.SolutionResponse:
   type: object
   required:

--- a/json/components/network-sourcing/ns3.yml
+++ b/json/components/network-sourcing/ns3.yml
@@ -156,6 +156,39 @@ NS3.Node.Flow:
       items:
         $ref: '#/NS3.UnitDimensionCost'
 
+NS3.Node.ProductTransform.Item:
+  type: object
+  properties:
+    productId:
+      type: string
+    productRatio:
+      type: number
+      format: float
+    dimensionRanges:
+      type: array
+      items:
+        $ref: '#/NS3.DimensionRange'
+    fixedDimensionCosts:
+      type: array
+      items:
+        $ref: '#/NS3.FixedDimensionCost'
+    unitDimensionCosts:
+      type: array
+      items:
+        $ref: '#/NS3.UnitDimensionCost'
+
+NS3.Node.ProductTransform:
+  type: object
+  properties:
+    inputItems:
+      type: array
+      items: 
+        $ref: '#/NS3.Node.ProductTransform.Item'
+    outputItems:
+      type: array
+      items:
+        $ref: '#/NS3.Node.ProductTransform.Item'
+
 NS3.Node:
   type: object
   required:
@@ -192,6 +225,10 @@ NS3.Node:
       type: array
       items:
         $ref: '#/NS3.FlowDimensionalConstraint'
+    productTransforms:
+      type: array
+      items:
+        $ref: '#/NS3.Node.ProductTransform'
 
 NS3.ProductSpecification:
   type: object

--- a/json/components/network-sourcing/ns3.yml
+++ b/json/components/network-sourcing/ns3.yml
@@ -180,6 +180,8 @@ NS3.Node.ProductTransform.Item:
 NS3.Node.ProductTransform:
   type: object
   properties:
+    productTransformId:
+      type: string
     inputItems:
       type: array
       items: 
@@ -534,6 +536,32 @@ NS3.SolutionResponse.Route:
         type: integer
         format: int32
 
+NS3.SolutionResponse.NodeProductTransformAssignment:
+  type: object
+  properties:
+    nodeId:
+      type: string
+    productTransformId:
+      type: string
+    inputProductId:
+      type: array
+      items:
+        type: string
+    inputAmount:
+      type: array
+      items:
+        type: number
+        format: float
+    outputProductId:
+      type: array
+      items:
+        type: string
+    outputAmount:
+      type: array
+      items:
+        type: number
+        format: float
+
 NS3.SolutionResponse:
   type: object
   required:
@@ -568,6 +596,10 @@ NS3.SolutionResponse:
       type: array
       items:
         $ref: '#/NS3.SolutionResponse.Route'
+    nodeProductTransformAssignments:
+      type: array
+      items:
+        $ref: '#/NS3.SolutionResponse.NodeProductTransformAssignment'
 
 NS3.SolverResponse:
   type: object

--- a/pbf/ns3-tbfvuwtge2iq.proto
+++ b/pbf/ns3-tbfvuwtge2iq.proto
@@ -90,8 +90,7 @@ message Node {
     required string productId = 1;
     repeated DimensionRange dimensionRanges = 2;
     repeated FixedDimensionCost FixedDimensionCosts = 3;
-    repeated UnitDimensionCost unitDimensionCosts =
-        4;  // individual factoring and costs per dimension.
+    repeated UnitDimensionCost unitDimensionCosts = 4;  // individual factoring and costs per dimension.
   }
   message Flow {  // across all products
     repeated DimensionRange dimensionRanges = 1;
@@ -99,21 +98,36 @@ message Node {
     repeated UnitDimensionCost unitDimensionCosts = 3;
   }
 
+  // essentially a Node.ProductTransform which may be applied at this node.
+  // this means that the node MAY convert the input products (in their respective ratios)
+  // into the output products (in their respective ratios). Costing at a transformer flow level can 
+  // be applied however granular.
+  message ProductTransform { 
+    message Item {
+      required string productId = 1;
+      required float productRatio = 2;
+      repeated DimensionRange dimensionRanges = 3;
+      repeated FixedDimensionCost fixedDimensionCosts = 4;
+      repeated UnitDimensionCost unitDimensionCosts = 5;
+    }
+    // input product id's defining the transform (with their respective ratio) 
+    // specify at least one.
+    repeated Item inputItems = 1;
+    // output product id's defining the transform (with their respective ratio) 
+    // specify at least one.
+    repeated Item outputItems = 2;
+  }
+
   required string id = 1;
   required Geocode geocode = 2;
   repeated ProductFlow production = 3;
   repeated ProductFlow consumption = 4;
-  optional Flow flow = 5;  // summing across all products+ dimensions, applies
-                           // ranges, dimension costs etc.
-  repeated ProductFlow productFlows =
-      6;  // individual product flows that are applied at a node level (mostly
-          // intermediate nodes).
-  repeated string allowableSources = 7;  // can be a sinlge source, or many.
-  optional int32 maximumSources = 8
-      [default = -1];  // set to 1 where a single source decision is required.
-  repeated FlowDimensionalConstraint flowConstraints =
-      9;  // the maximum flow over this node (sum of all incoming arcs |
-          // unit+dims)
+  optional Flow flow = 5;  // summing across all products+ dimensions, applies ranges, dimension costs etc.
+  repeated ProductFlow productFlows = 6;  // individual product flows that are applied at a node level (mostly intermediate nodes).
+  repeated string allowableSources = 7;   // can be a sinlge source, or many.
+  optional int32 maximumSources = 8 [default = -1];  // set to 1 where a single source decision is required.
+  repeated FlowDimensionalConstraint flowConstraints =  9;  // the maximum flow over this node (sum of all incoming arcs | unit+dims)
+  repeated ProductTransform productTransforms = 10; // set of product transformer which may be used to satisfy other flows.
 }
 
 // https://docs.icepack.ai/ns3/product-group/
@@ -135,10 +149,9 @@ message LaneRate {
   required string source = 3;
   required string destination = 4;
   repeated string productIds = 5;  // Allowable products on this lane rate
-  repeated string productGroupIds =
-      6;  // alternatively, the allowable product groups on this lane rate
-          // If both product ids and product group ids are specified, the
-          // intersection of these two is used.
+  repeated string productGroupIds = 6;  // alternatively, the allowable product groups on this lane rate
+                                        // If both product ids and product group ids are specified, the
+                                        // intersection of these two is used.
   repeated UnitDimensionCost unitDimensionCosts = 7;
   // unit dimensions may be items such as a cost per load, cost per km,
   // cost per unit km, or some combination of whatwhever. Mutliple units
@@ -154,8 +167,7 @@ message LaneRate {
 message CostModel {
   required string id = 1;
   required string source = 2;
-  repeated string productGroupIds =
-      3;  // cost models only work with product groups.
+  repeated string productGroupIds = 3;  // cost models only work with product groups.
   repeated UnitDimensionCost unitDimensionCosts = 4;
   repeated FlowDimensionalConstraint flowConstraints = 5;
 }

--- a/pbf/ns3-tbfvuwtge2iq.proto
+++ b/pbf/ns3-tbfvuwtge2iq.proto
@@ -255,19 +255,30 @@ message SolutionResponse {
     repeated float x = 1;
     repeated float y = 2;
   }
+
   message Route {
     required string fromId = 1;
     required string toId = 2;
     repeated int32 geometrySequence = 3;
   }
+
   message NodeProductTransformAssignment {
+    message Item {
+      required string productId = 1;
+      required float amount = 2;
+      required float cost = 3;          // from the UnitDimensionCosts
+      required float fixedCost = 4;     // from the fixedDimensionCosts
+      required float penaltyAmount = 5; // from the DimRanges
+      required float penaltyCost = 6;   // from the DimRanges
+    }
+    
+    // identifiers
     required string nodeId = 1;
     required string productTransformId = 2;
-    
-    repeated string inputProductId = 3;
-    repeated float inputAmount = 4;
-    repeated string outputProductId = 5;
-    repeated float outputAmount = 6;
+
+    // input+output terms / ratios
+    repeated Item inputItems = 3;
+    repeated Item outputItems = 4;
   }
 
   required float objective = 1;

--- a/pbf/ns3-tbfvuwtge2iq.proto
+++ b/pbf/ns3-tbfvuwtge2iq.proto
@@ -105,7 +105,7 @@ message Node {
   message ProductTransform { 
     message Item {
       required string productId = 1;
-      required float productRatio = 2;
+      required int32 productRatio = 2;
       repeated DimensionRange dimensionRanges = 3;
       repeated FixedDimensionCost fixedDimensionCosts = 4;
       repeated UnitDimensionCost unitDimensionCosts = 5;

--- a/pbf/ns3-tbfvuwtge2iq.proto
+++ b/pbf/ns3-tbfvuwtge2iq.proto
@@ -110,12 +110,16 @@ message Node {
       repeated FixedDimensionCost fixedDimensionCosts = 4;
       repeated UnitDimensionCost unitDimensionCosts = 5;
     }
+    
+    // in order to identify the item in the outputs
+    required string productTransformId = 1;
+
     // input product id's defining the transform (with their respective ratio) 
     // specify at least one.
-    repeated Item inputItems = 1;
+    repeated Item inputItems = 2;
     // output product id's defining the transform (with their respective ratio) 
     // specify at least one.
-    repeated Item outputItems = 2;
+    repeated Item outputItems = 3;
   }
 
   required string id = 1;
@@ -256,6 +260,15 @@ message SolutionResponse {
     required string toId = 2;
     repeated int32 geometrySequence = 3;
   }
+  message NodeProductTransformAssignment {
+    required string nodeId = 1;
+    required string productTransformId = 2;
+    
+    repeated string inputProductId = 3;
+    repeated float inputAmount = 4;
+    repeated string outputProductId = 5;
+    repeated float outputAmount = 6;
+  }
 
   required float objective = 1;
   optional float lowerBound = 2;
@@ -265,4 +278,5 @@ message SolutionResponse {
   repeated NodeProductFlow nodeProductFlows = 6;
   repeated GeometrySequence geometrySequence = 7;
   repeated Route routes = 8;
+  repeated NodeProductTransformAssignment nodeProductTransformAssignments = 9;
 }


### PR DESCRIPTION
Product transform at Nodes in the NS3 model. 
Useful for modelling the translation of products from one state to another, or a recipe-style working to create new products. Supports 1:1, 1:M, M:1 and M:M mappings of products. Note, the NS3 model enforces the conservation of flow so if the ratios supplied result in an excess of product being produced, a waste/sink node may be required to take up the excess.