### PR TITLE
schema change for task-vehicle attributes

### DIFF
--- a/json/components/vehicle-router/ivr7.yml
+++ b/json/components/vehicle-router/ivr7.yml
@@ -160,6 +160,10 @@ IVR7.Job.Task.Attribute:
       type: array
       items:
         $ref: '#/IVR7.Window'
+    vehicleIds:
+      type: array
+      items:
+        type: string
 
 IVR7.Job.Task:
   type: object

--- a/json/components/vehicle-router/ivr8.yml
+++ b/json/components/vehicle-router/ivr8.yml
@@ -173,6 +173,10 @@ IVR8.Job.Task.Attribute:
       type: array
       items:
         $ref: '#/IVR8.Window'
+    vehicleIds:
+      type: array
+      items:
+        type: string
 
 IVR8.Job.Task.TaskRelation:
   type: object

--- a/pbf/ivr7-kt461v8eoaif.proto
+++ b/pbf/ivr7-kt461v8eoaif.proto
@@ -92,6 +92,7 @@ message Job {
       required string dimensionId = 1;
       optional float quantity = 2;
       repeated Window windows = 3;
+      repeated string vehicleIds = 4; // when empty, applies to all vehicles.
     }
     enum TripConstraint {
       FIRST = 0;  // first on trip

--- a/pbf/ivr8-yni1c9k2swof.proto
+++ b/pbf/ivr8-yni1c9k2swof.proto
@@ -102,6 +102,7 @@ message Job {
       required string dimensionId = 1;
       optional float quantity = 2;
       repeated Window windows = 3;
+      repeated string vehicleIds = 4; // when empty, applies to all vehicles.
     }
     enum TripConstraint {
       FIRST = 0;  // first on trip


### PR DESCRIPTION
* allows the specification of vehicle-specific task quantities
* as well as potential subsets of windows that may be applied to a task-vehicle pair
* empty vehicle assignment applied the attribute to all vehicles
* can be used to "layer" values onto vehicles, the last value specified will be used.